### PR TITLE
refactor: improve readablity & performance regarding QString

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -19,12 +19,20 @@ bool CAJ2PDF::eventFilter(QObject *object, QEvent *event) {
   if (event->type() == QEvent::EnterWhatsThisMode) {
     // 弹出一个关于本项目信息的消息框
     QMessageBox::information(
-        this, QString::fromUtf8("关于"),
-        QString::fromUtf8(
-            std::string(
-                "<h2 align=\"center\">关于本项目</h2><br><p style=\"line-height:150%\">这是一个免费开源的 CAJ 转 PDF 转换器，基于 <a href=\"https://github.com/caj2pdf/caj2pdf\">cajpdf</a> 和 <a href=\"https://mupdf.com/\">mupdf</a> 实现。<br>主页：<a href=\"https://caj2pdf-qt.sainnhe.dev\">https://caj2pdf-qt.sainnhe.dev</a><br>作者：<a href=\"mailto:i@sainnhe.dev\">Sainnhe Park</a><br>许可：<a href=\"https://github.com/sainnhe/caj2pdf-qt/blob/master/LICENSE\">GPL3</a><br>版本：<a href=\"https://caj2pdf-qt.sainnhe.dev/CHANGELOG.html\">" +
-                version + "</a></p>")
-                .c_str()));
+        this, QStringLiteral("关于"),
+        QStringLiteral(
+            "<h2 align=\"center\">关于本项目</h2><br><p "
+            "style=\"line-height:150%\">这是一个免费开源的 CAJ 转 PDF "
+            "转换器，基于 <a "
+            "href=\"https://github.com/caj2pdf/caj2pdf\">cajpdf</a> 和 <a "
+            "href=\"https://mupdf.com/\">mupdf</a> 实现。<br>主页：<a "
+            "href=\"https://caj2pdf-qt.sainnhe.dev\">https://"
+            "caj2pdf-qt.sainnhe.dev</a><br>作者：<a "
+            "href=\"mailto:i@sainnhe.dev\">Sainnhe Park</a><br>许可：<a "
+            "href=\"https://github.com/sainnhe/caj2pdf-qt/blob/master/"
+            "LICENSE\">GPL3</a><br>版本：<a "
+            "href=\"https://caj2pdf-qt.sainnhe.dev/CHANGELOG.html\">%1</a></p>")
+            .arg(QString::fromStdString(version)));
     return true;
   }
   return QObject::eventFilter(object, event);
@@ -66,9 +74,9 @@ void CAJ2PDF::dropEvent(QDropEvent *event) {
                       inputFilesVec.end());
   inputFiles = inputFilesVec.toList();
   // 更新文本框
-  QString inputFilesText = tr("");
+  QString inputFilesText;
   for (QString str : inputFiles) {
-    inputFilesText = inputFilesText + str + "\n";
+    inputFilesText += str + "\n";
   }
   inputTextBrowser->setText(inputFilesText);
   outputTextBrowser->setText(inputFilesText);

--- a/src/slots/page1.cpp
+++ b/src/slots/page1.cpp
@@ -27,9 +27,9 @@ void CAJ2PDF::handlePage1SelectInputButton() {
                       inputFilesVec.end());
   inputFiles = inputFilesVec.toList();
   // 更新文本框
-  QString inputFilesText = tr("");
+  QString inputFilesText;
   for (QString str : inputFiles) {
-    inputFilesText = inputFilesText + str + "\n";
+    inputFilesText += str + "\n";
   }
   inputTextBrowser->setText(inputFilesText);
   outputTextBrowser->setText(inputFilesText);

--- a/src/slots/page3.cpp
+++ b/src/slots/page3.cpp
@@ -40,10 +40,10 @@ void CAJ2PDF::updatePage3Progress(bool status, QString inputFilePath) {
   progressBar->setValue(progressBar->value() + 1);
   if (status) {
     statusTextBrowser->insertPlainText(
-        QString::fromStdString("✅ " + inputFilePath.toStdString() + "\n"));
+        QStringLiteral("✅ %1\n").arg(inputFilePath));
   } else {
     statusTextBrowser->insertPlainText(
-        QString::fromStdString("❌ " + inputFilePath.toStdString() + "\n"));
+        QStringLiteral("❌ %1\n").arg(inputFilePath));
   }
   page3Mutex->unlock();
 }

--- a/src/threads/conversion.cpp
+++ b/src/threads/conversion.cpp
@@ -48,9 +48,9 @@ void ConversionThread::run() {
                            .filePath(QString::fromStdString(outputFileName));
   // 执行命令，成功返回 0
   QProcess process;
-  QStringList args = {QString::fromUtf8("convert"), inputFilePath,
-                      QString::fromUtf8("-o"),      outputFile,
-                      QString::fromUtf8("-m"),      mutoolExecutablePath};
+  QStringList args = {QLatin1String("convert"), inputFilePath,
+                      QLatin1String("-o"),      outputFile,
+                      QLatin1String("-m"),      mutoolExecutablePath};
   // 开始执行命令，转换完成后发送信号，根据转换结果更新第三页的页面
   emit conversionFinished(process.execute(caj2pdfExecutablePath, args) == 0,
                           inputFilePath);


### PR DESCRIPTION
1. When the string is non-empty, `QLatin1String()` & `QStringLiteral()` offers better performance than the `QString()` constructor.

2. When concatenating strings, `arg()` offers better readablity than a chain of `+`.